### PR TITLE
Do not label DKIM signatures

### DIFF
--- a/postfix_exporter.go
+++ b/postfix_exporter.go
@@ -396,7 +396,7 @@ func (e *PostfixExporter) CollectFromLogLine(line string) {
 		}
 	case "opendkim":
 		if opendkimMatches := opendkimSignatureAdded.FindStringSubmatch(remainder); opendkimMatches != nil {
-			e.opendkimSignatureAdded.WithLabelValues(opendkimMatches[1], opendkimMatches[2]).Inc()
+			e.opendkimSignatureAdded.WithLabelValues("", "").Inc()
 		} else {
 			e.addToUnsupportedLine(line, process)
 		}


### PR DESCRIPTION
By default, the exporter keeps a list of the number of DKIM signatures
by domain. It slows down significantly the exporter after several weeks
of running.

To avoid that, we keep a global counter.